### PR TITLE
Implement backend API endpoints

### DIFF
--- a/backend-api/Dockerfile
+++ b/backend-api/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend-api/file_processor/__init__.py
+++ b/backend-api/file_processor/__init__.py
@@ -1,1 +1,10 @@
-# Handles text extraction from unstructured files
+"""Utilities for processing uploaded files."""
+
+from fastapi import UploadFile
+
+
+def extract_text(file: UploadFile) -> str:
+    """Read file contents as text."""
+    content = file.file.read().decode("utf-8", errors="ignore")
+    file.file.seek(0)
+    return content

--- a/backend-api/gemini_connector/__init__.py
+++ b/backend-api/gemini_connector/__init__.py
@@ -1,11 +1,23 @@
-# filepath: c:\Project\ChatBot\backend-api\gemini_connector\__init__.py
+"""Simple Gemini API connector stub."""
+
 import requests
 
-# Connects and sends prompt to Gemini API
-def query_gemini(prompt: str):
-    response = requests.post(
-        "https://gemini-api.example.com/query",
-        json={"prompt": prompt},
-        headers={"Authorization": "Bearer YOUR_API_KEY"}
-    )
-    return response.json()
+GEMINI_ENDPOINT = "https://gemini-api.example.com/query"
+API_KEY = "YOUR_API_KEY"
+
+
+def query_gemini(prompt: str) -> str:
+    """Send the prompt to the Gemini API and return the response text."""
+    try:
+        response = requests.post(
+            GEMINI_ENDPOINT,
+            json={"prompt": prompt},
+            headers={"Authorization": f"Bearer {API_KEY}"},
+            timeout=10,
+        )
+        response.raise_for_status()
+        data = response.json()
+        return data.get("response", "")
+    except requests.RequestException:
+        # In this demo environment we simply echo the prompt
+        return f"Gemini response for: {prompt}"

--- a/backend-api/main.py
+++ b/backend-api/main.py
@@ -1,12 +1,15 @@
 from fastapi import FastAPI
-from routers import chat, admin, status
 
-app = FastAPI()
+from .routers import chat, admin, status
+
+app = FastAPI(title="ChatBot Backend")
 
 app.include_router(chat.router)
 app.include_router(admin.router)
 app.include_router(status.router)
 
-@app.get('/')
+
+@app.get("/")
 def root():
+    """Basic health check endpoint."""
     return {"message": "AI Chatbot Backend Running"}

--- a/backend-api/prompt_engine/__init__.py
+++ b/backend-api/prompt_engine/__init__.py
@@ -1,1 +1,8 @@
-# Combines prompt + context + user input
+"""Simple prompt construction utilities."""
+
+SYSTEM_PROMPT = "You are a helpful assistant."
+
+
+def build_prompt(user_input: str) -> str:
+    """Combine the system prompt with user input."""
+    return f"{SYSTEM_PROMPT}\nUser: {user_input}"

--- a/backend-api/requirements.txt
+++ b/backend-api/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+requests

--- a/backend-api/routers/admin.py
+++ b/backend-api/routers/admin.py
@@ -1,7 +1,14 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, UploadFile, File
 
-router = APIRouter(prefix='/admin')
+from ..file_processor import extract_text
+from ..vector_indexing import add_document
 
-@router.post('/upload')
-def upload_file():
-    return {"status": "uploaded"}
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+
+@router.post("/upload")
+def upload_file(file: UploadFile = File(...)):
+    """Upload a text file and index its contents."""
+    content = extract_text(file)
+    add_document(file.filename, content)
+    return {"status": "uploaded", "filename": file.filename}

--- a/backend-api/routers/chat.py
+++ b/backend-api/routers/chat.py
@@ -1,9 +1,24 @@
 from fastapi import APIRouter
-from gemini_connector import query_gemini
+from pydantic import BaseModel
 
-router = APIRouter(prefix='/chat')
+from ..gemini_connector import query_gemini
+from ..prompt_engine import build_prompt
 
-@router.post('/')
-def chat(prompt: str):
-    response = query_gemini(prompt)
-    return {"response": response}
+
+router = APIRouter(prefix="/chat", tags=["chat"])
+
+
+class ChatRequest(BaseModel):
+    message: str
+
+
+class ChatResponse(BaseModel):
+    response: str
+
+
+@router.post("/", response_model=ChatResponse)
+def chat(request: ChatRequest):
+    """Proxy user message to the Gemini API."""
+    prompt = build_prompt(request.message)
+    response_text = query_gemini(prompt)
+    return ChatResponse(response=response_text)

--- a/backend-api/routers/status.py
+++ b/backend-api/routers/status.py
@@ -1,7 +1,9 @@
 from fastapi import APIRouter
 
-router = APIRouter(prefix='/status')
+router = APIRouter(prefix="/status", tags=["status"])
 
-@router.get('/')
+
+@router.get("/")
 def status():
+    """Return service status."""
     return {"status": "ok"}

--- a/backend-api/vector_indexing/__init__.py
+++ b/backend-api/vector_indexing/__init__.py
@@ -1,1 +1,17 @@
-# Handles FAISS or ChromaDB vector indexing
+"""Basic in-memory vector index placeholder."""
+
+from pathlib import Path
+import json
+
+INDEX_FILE = Path(__file__).resolve().parent / "index.json"
+
+if INDEX_FILE.exists():
+    _INDEX = json.loads(INDEX_FILE.read_text())
+else:
+    _INDEX = {}
+
+
+def add_document(name: str, content: str) -> None:
+    """Store document text in a simple JSON index."""
+    _INDEX[name] = content
+    INDEX_FILE.write_text(json.dumps(_INDEX, indent=2))


### PR DESCRIPTION
## Summary
- flesh out FastAPI backend
- add admin file upload endpoint
- add chat endpoint stubs for Gemini integration
- include Dockerfile and requirements

## Testing
- `pytest -q`
- `python -m uvicorn backend-api.main:app --port 8000 --host 0.0.0.0 --log-level warning` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_68400ea255e4832086c8f91459bac1de