### PR TITLE
Add unit tests for backend modules

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,39 @@
+import sys
+import types
+from pathlib import Path
+
+# Expose the backend-api directory as a package named `backend_api`
+package_path = Path(__file__).resolve().parents[1] / "backend-api"
+backend_pkg = types.ModuleType("backend_api")
+backend_pkg.__path__ = [str(package_path)]
+sys.modules.setdefault("backend_api", backend_pkg)
+
+# Provide a minimal `requests` stub if the real library is unavailable
+if "requests" not in sys.modules:
+    requests = types.ModuleType("requests")
+
+    class DummyResponse:
+        def __init__(self, data):
+            self._data = data
+        def json(self):
+            return self._data
+        def raise_for_status(self):
+            pass
+
+    def post(url, json=None, headers=None, timeout=None):
+        return DummyResponse({"response": f"Gemini response for: {json.get('prompt', '')}"})
+
+    requests.post = post
+    sys.modules["requests"] = requests
+
+# Provide a minimal 'python-multipart' stub to satisfy FastAPI when parsing UploadFile
+if 'multipart' not in sys.modules:
+    multipart = types.ModuleType('multipart')
+    multipart.__version__ = '0.0'
+    sub = types.ModuleType('multipart.multipart')
+    def parse_options_header(value):
+        return None, {}
+    sub.parse_options_header = parse_options_header
+    multipart.multipart = sub
+    sys.modules['multipart'] = multipart
+    sys.modules['multipart.multipart'] = sub

--- a/tests/test_file_processor.py
+++ b/tests/test_file_processor.py
@@ -1,0 +1,19 @@
+import importlib
+from fastapi import UploadFile
+from io import BytesIO
+
+fp = importlib.import_module('backend_api.file_processor')
+
+
+def make_upload(name: str, data: bytes) -> UploadFile:
+    return UploadFile(filename=name, file=BytesIO(data))
+
+
+def test_extract_text_plain():
+    f = make_upload('sample.txt', b'hello')
+    assert fp.extract_text(f) == 'hello'
+
+
+def test_extract_text_pdf_without_pypdf():
+    f = make_upload('sample.pdf', b'%PDF-1.4')
+    assert fp.extract_text(f) == ''

--- a/tests/test_prompt_engine.py
+++ b/tests/test_prompt_engine.py
@@ -1,0 +1,16 @@
+import importlib
+
+pe = importlib.import_module('backend_api.prompt_engine')
+
+
+def test_build_prompt_with_context():
+    pe.set_system_prompt('SYSTEM')
+    prompt = pe.build_prompt('hello', context='info')
+    assert 'SYSTEM' in prompt
+    assert 'Context:\ninfo' in prompt
+    assert prompt.strip().endswith('User: hello')
+
+
+def test_set_system_prompt_affects_build():
+    pe.set_system_prompt('NEW PROMPT')
+    assert pe.build_prompt('x').splitlines()[0] == 'NEW PROMPT'

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,40 @@
+import importlib
+from pathlib import Path
+from io import BytesIO
+from fastapi import UploadFile
+
+import backend_api.gemini_connector as gc
+import backend_api.vector_indexing as vi
+import backend_api.routers.admin as admin
+import backend_api.routers.chat as chat
+import backend_api.routers.status as status
+
+
+def setup_patches(monkeypatch):
+    monkeypatch.setattr(gc, 'query_gemini', lambda p: f'ECHO:{p}')
+    monkeypatch.setattr(chat, 'query_gemini', lambda p: f'ECHO:{p}')
+    monkeypatch.setattr(vi, 'INDEX_FILE', Path('/tmp/index.json'))
+    monkeypatch.setattr(vi, '_DOCUMENTS', {})
+    monkeypatch.setattr(vi, '_TOKENS', {})
+    monkeypatch.setattr(vi, '_persist', lambda: None)
+    monkeypatch.setattr(admin, 'extract_text', lambda f: 'txt')
+    monkeypatch.setattr(admin, 'add_document', lambda n, c: None)
+
+
+def test_status(monkeypatch):
+    setup_patches(monkeypatch)
+    assert status.status() == {'status': 'ok'}
+
+
+def test_chat(monkeypatch):
+    setup_patches(monkeypatch)
+    response = chat.chat(chat.ChatRequest(message='hi'))
+    assert response.response.startswith('ECHO:')
+
+
+def test_upload(monkeypatch):
+    setup_patches(monkeypatch)
+    file = UploadFile(filename='t.txt', file=BytesIO(b'data'))
+    result = admin.upload_file(file)
+    assert result['status'] == 'uploaded'
+    assert result['filename'] == 't.txt'

--- a/tests/test_vector_indexing.py
+++ b/tests/test_vector_indexing.py
@@ -1,0 +1,16 @@
+import importlib
+
+vi = importlib.import_module('backend_api.vector_indexing')
+
+
+def test_add_search(tmp_path, monkeypatch):
+    monkeypatch.setattr(vi, 'INDEX_FILE', tmp_path / 'index.json')
+    monkeypatch.setattr(vi, '_DOCUMENTS', {})
+    monkeypatch.setattr(vi, '_TOKENS', {})
+    monkeypatch.setattr(vi, '_persist', lambda: None)
+
+    vi.add_document('doc1', 'hello world')
+    assert vi.get_document('doc1') == 'hello world'
+
+    results = vi.search('hello')
+    assert ('doc1', 1) in results


### PR DESCRIPTION
## Summary
- add pytest configuration and stub modules for missing deps
- add tests for prompt engine, vector indexing, file processor and router logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684019334b8c832088ab777cb53a1f91